### PR TITLE
Fix missing package for InMemoryJobRepository

### DIFF
--- a/app/src/main/java/com/example/careerconnect/data/RepositoryProvider.kt
+++ b/app/src/main/java/com/example/careerconnect/data/RepositoryProvider.kt
@@ -1,6 +1,6 @@
 package com.example.careerconnect.data
 
-import InMemoryJobRepository
+import com.example.careerconnect.data.impl.InMemoryJobRepository
 import com.example.careerconnect.data.impl.InMemoryTipRepository
 
 object RepositoryProvider {

--- a/app/src/main/java/com/example/careerconnect/data/impl/InMemoryJobRepository.kt
+++ b/app/src/main/java/com/example/careerconnect/data/impl/InMemoryJobRepository.kt
@@ -1,3 +1,5 @@
+package com.example.careerconnect.data.impl
+
 import com.example.careerconnect.Job
 import com.example.careerconnect.data.JobRepository
 


### PR DESCRIPTION
## Summary
- declare package for `InMemoryJobRepository`
- import job repository implementation with correct package

## Testing
- `bash gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b908df7e388327904e8febf48849b3