### PR TITLE
feat: center login text and add join link

### DIFF
--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -53,6 +53,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
                     android:text="@string/welcome_back"
                     android:textSize="20sp"
                     android:textStyle="bold" />
@@ -60,6 +61,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
                     android:paddingBottom="12dp"
                     android:text="@string/sign_in_message"
                     android:textColor="#6B7280" />
@@ -103,6 +105,16 @@
                     android:layout_gravity="center_horizontal"
                     android:layout_marginTop="8dp"
                     android:text="@string/forgot_password"
+                    android:textColor="@color/cc_primary"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/tvJoin"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
+                    android:layout_marginTop="12dp"
+                    android:text="@string/new_to_career_connect"
                     android:textColor="@color/cc_primary"
                     android:textStyle="bold" />
             </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="app_tagline">Your professional network awaits</string>
     <string name="welcome_back">Welcome back</string>
     <string name="sign_in_message">Sign in to advance your career</string>
+    <string name="new_to_career_connect">New to Career Connect? Join now</string>
     <string name="forgot_password">Forgot password?</string>
     <string name="connect_with_professionals">Connect with professionals</string>
     <string name="find_dream_job">Find your dream job</string>


### PR DESCRIPTION
## Summary
- center welcome and sign-in messages on login screen
- invite new users with join link on login page

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b932fa6b408327aaddb81d29d5113f