### PR TITLE
Enhance profile page with mission and achievements

### DIFF
--- a/app/src/main/java/com/example/careerconnect/DataProvider.kt
+++ b/app/src/main/java/com/example/careerconnect/DataProvider.kt
@@ -34,7 +34,18 @@ object DataProvider {
         name = "John Doe",
         headline = "Senior Software Engineer at TechCorp Inc.",
         about = "Passionate software engineer with 6+ years of experience building scalable web applications.",
-        skills = listOf("JavaScript", "React", "Node.js", "TypeScript", "AWS", "Docker"),
+        mission = "To push boundaries, solve the unsolvable, and brighten the world with code.",
+        skills = listOf(
+            "JavaScript",
+            "React",
+            "Node.js",
+            "TypeScript",
+            "AWS",
+            "Docker",
+            "Ideas Dynamo",
+            "Deadline Ninja",
+            "Team Whisperer"
+        ),
         preferences = "Remote • $120k–$160k • Full-time",
         experience = listOf(
             Experience(
@@ -47,6 +58,11 @@ object DataProvider {
                 companyLine = "StartupXYZ • 2020–2022 • New York, NY",
                 desc = "Built end‑to‑end web applications using modern JavaScript frameworks and cloud technologies."
             )
+        ),
+        achievements = listOf(
+            "Invented a productivity system so efficient it's practically a time machine",
+            "Voted 'Most Likely to Save the Day' five years running",
+            "Launched products with a 100% success rate (if imagination counts)"
         )
     )
 }

--- a/app/src/main/java/com/example/careerconnect/ProfileActivity.kt
+++ b/app/src/main/java/com/example/careerconnect/ProfileActivity.kt
@@ -1,6 +1,7 @@
 package com.example.careerconnect
 
 import android.os.Bundle
+import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.careerconnect.databinding.ActivityProfileBinding
@@ -22,6 +23,7 @@ class ProfileActivity : AppCompatActivity() {
         binding.tvName.text = p.name
         binding.tvHeadline.text = p.headline
         binding.tvAbout.text = p.about
+        binding.tvMission.text = p.mission
         binding.tvPrefs.text = p.preferences
 
         p.skills.forEach { skill ->
@@ -32,6 +34,12 @@ class ProfileActivity : AppCompatActivity() {
 
         binding.rvExperience.layoutManager = LinearLayoutManager(this)
         binding.rvExperience.adapter = ExperienceAdapter(p.experience)
+
+        p.achievements.forEach { achievement ->
+            val tv = TextView(this)
+            tv.text = "• $achievement"
+            binding.llAchievements.addView(tv)
+        }
     }
 
     // Handle back arrow press

--- a/app/src/main/java/com/example/careerconnect/models.kt
+++ b/app/src/main/java/com/example/careerconnect/models.kt
@@ -20,7 +20,9 @@ data class Profile(
     val name: String,
     val headline: String,
     val about: String,
+    val mission: String,
     val skills: List<String>,
     val preferences: String,
-    val experience: List<Experience>
+    val experience: List<Experience>,
+    val achievements: List<String>
 )

--- a/app/src/main/res/layout/activity_profile.xml
+++ b/app/src/main/res/layout/activity_profile.xml
@@ -77,7 +77,30 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@string/skills"
+                    android:text="@string/mission_statement"
+                    android:textStyle="bold"/>
+                <TextView
+                    android:id="@+id/tvMission"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingTop="8dp"/>
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            app:cardCornerRadius="12dp">
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="16dp">
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/super_skills"
                     android:textStyle="bold"/>
                 <com.google.android.material.chip.ChipGroup
                     android:id="@+id/chipsSkills"
@@ -106,6 +129,30 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:nestedScrollingEnabled="false"/>
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            app:cardCornerRadius="12dp">
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="16dp">
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/legendary_achievements"
+                    android:textStyle="bold"/>
+                <LinearLayout
+                    android:id="@+id/llAchievements"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:paddingTop="8dp"/>
             </LinearLayout>
         </com.google.android.material.card.MaterialCardView>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,6 +27,9 @@
     <string name="passionate_software_engineer_with_6_years_of_experience_building_scalable_web_applications">Passionate software engineer with 6+ years of experience building scalable web applications.</string>
     <string name="edit_profile">Edit Profile</string>
     <string name="skills">Skills</string>
+    <string name="super_skills">Super Skills</string>
+    <string name="mission_statement">Mission Statement</string>
+    <string name="legendary_achievements">Legendary Achievements</string>
     <string name="professional_experience">Professional Experience</string>
     <string name="job_preferences">Job Preferences</string>
     <string name="remote_120k_160k_full_time">Remote • $120k–$160k • Full-time</string>


### PR DESCRIPTION
## Summary
- extend profile model with mission statement and achievements
- add new sections to profile screen for mission, super skills, and achievements
- seed DataProvider with imaginative skills and accomplishments

## Testing
- `./gradlew test` *(fails: Gradle download succeeded but build did not finish in time)*

------
https://chatgpt.com/codex/tasks/task_e_68b93794cb8c8327ae3650374a9ce614